### PR TITLE
Allow custom url path mapping.

### DIFF
--- a/src/lib/index/server.js
+++ b/src/lib/index/server.js
@@ -116,6 +116,7 @@ class Server extends EventEmitter {
 	 * @param {Function[]} config.middlewares - The middleware functions for this route.
 	 * @param {Function} config.responseWriter - The function to use before writing the response.
 	 * @param {string} [config.endpoint=/] - The API endpoint.
+	 * @param {Function} [config.pathMapper] - A function to map from a namespace string to a URL path string.
 	 * 
 	 * @returns {Server} The server.
 	 */
@@ -133,11 +134,11 @@ class Server extends EventEmitter {
 			schemaNameParts = fullSchemaName.split('.'),
 			schemaNamespace = _.initial(schemaNameParts).join('.'),
 			schemaName = _.last(schemaNameParts),
-			apiEndpoint = `${config.endpoint}${schemaNamespace}`.replace(/\./g, '/'),
+			apiEndpoint = config.endpoint + config.pathMapper(schemaNamespace);
 
-			routeConfiguration = _.get(me, `${PROPERTY_ROUTE_CONFIGURATION}.${apiEndpoint}`, {});
-
-		let router = _.get(me[PROPERTY_ROUTER_CONFIGURATION], apiEndpoint);
+		let
+			routeConfiguration = me[PROPERTY_ROUTE_CONFIGURATION][apiEndpoint],
+			router = me[PROPERTY_ROUTER_CONFIGURATION][apiEndpoint];
 
 		// If we don't have the router for this endpoint then we need to create one.
 		if (!router) {
@@ -156,13 +157,17 @@ class Server extends EventEmitter {
 			me[PROPERTY_SERVER].use(apiEndpoint, router);
 
 			// Update the router configuration.
-			_.set(me[PROPERTY_ROUTER_CONFIGURATION], apiEndpoint, router);
+			me[PROPERTY_ROUTER_CONFIGURATION][apiEndpoint] = router;
 
 		}
 
+		if (!routeConfiguration) {
+			routeConfiguration = {};
+			me[PROPERTY_ROUTE_CONFIGURATION][apiEndpoint] = routeConfiguration;
+		}
+
 		// Update the route configuration.
-		_.set(routeConfiguration, schemaName, schema);
-		_.set(me[PROPERTY_ROUTE_CONFIGURATION], apiEndpoint, routeConfiguration);
+		routeConfiguration[schemaName] = schema;
 
 		me.info(`Adding route: ${fullSchemaName}.`);
 

--- a/src/lib/index/validator/route.js
+++ b/src/lib/index/validator/route.js
@@ -98,6 +98,14 @@ class RouteValidator {
 			throw new Error('Invalid parameter: responseWriter is not a function.');
 		}
 
+		if (!config.pathMapper) {
+			config.pathMapper = (namespace => namespace.replace(/\./g, '/'));
+		}
+
+		if (!_.isFunction(config.pathMapper)) {
+			throw new Error('Invalid parameter: pathMapper is not a function.');
+		}
+
 		// Validate the schema
 		schema.validate(config);
 

--- a/src/spec/index/validator/route.spec.js
+++ b/src/spec/index/validator/route.spec.js
@@ -102,6 +102,24 @@ describe('index/validator/route.js', () => {
 
 		});
 
+		it('should return the schema if pathMapper is a function', () => {
+
+			// Given
+			const config = {
+				schema: avsc.Type.forSchema({
+					name: 'com.example.FullName',
+					type: 'record',
+					fields: []
+				}),
+				pathMapper: _.noop
+			};
+
+			// When
+			// Then
+			expect(routeValidator.validate(config)).to.eql(config);
+
+		});
+
 		describe('should throw an error', () => {
 
 			it('if no config is provided', () => {
@@ -263,6 +281,21 @@ describe('index/validator/route.js', () => {
 				// When
 				// Then
 				expect(() => routeValidator.validate(config)).to.throw(/^Invalid parameter: responseWriter is not a function\.$/);
+
+			});
+
+			it('if the pathMapper is not a function', () => {
+
+				// Given
+				const config = {
+					schema: '{"name":"com.example.FullName","type":"record","fields":[]}',
+					responseWriter: _.noop,
+					pathMapper: 23
+				};
+
+				// When
+				// Then
+				expect(() => routeValidator.validate(config)).to.throw(/^Invalid parameter: pathMapper is not a function\.$/);
 
 			});
 


### PR DESCRIPTION
A minor update to allow the addRoute configuration to include a custom mapper function to map URL path from Avro schema namespace. The default mapping only maps . to / this will allow other mappings like _ to . for example. 