### PR TITLE
Release/2018 09 24

### DIFF
--- a/CHANGELOG-8.md
+++ b/CHANGELOG-8.md
@@ -1,0 +1,13 @@
+# @financialforcedev/orizuru
+
+## 8.0.0
+
+### BREAKING CHANGES
+ 
+- Use generic types for the IOrizuruMessage.
+	- This will cause compile time errors even though there are no functional changes.
+
+### NEW FEATURES 
+
+- Add use and set functions to the server.
+- Export static function from express in the index.

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -2,6 +2,3 @@
 
 ## Latest changes (not yet released)
 
-- Use generic types for the IOrizuruMessage.
-- Add use and set functions to the server.
-- Export static function from express in the index.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru",
-	"version": "7.1.1",
+	"version": "8.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru",
-	"version": "7.1.1",
+	"version": "8.0.0",
 	"description": "Streamlined communication between Heroku dynos / other worker processes",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
# Release
## 8.0.0

### BREAKING CHANGES
 
- Use generic types for the IOrizuruMessage.
	- This will cause compile time errors even though there are no functional changes.

### NEW FEATURES 

- Add use and set functions to the server.
- Export static function from express in the index.
