### PR TITLE
Feature/update for node 10 changes

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,3 +1,7 @@
 # @financialforcedev/orizuru
 
 ## Latest changes (not yet released)
+
+- Update all dependencies to latest versions
+- Remove all references to `new Buffer()`
+	- Use `Buffer.from()` instead to remove deprecation warnings

--- a/doc/classes/handler.html
+++ b/doc/classes/handler.html
@@ -240,7 +240,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from EventEmitter.defaultMaxListeners</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1079">node/index.d.ts:1079</a></li>
+							<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1080">node/index.d.ts:1080</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -259,7 +259,7 @@
 								<p>Inherited from EventEmitter.addListener</p>
 								<p>Overrides EventEmitter.addListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1081">node/index.d.ts:1081</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1082">node/index.d.ts:1082</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -305,7 +305,7 @@
 								<p>Inherited from EventEmitter.emit</p>
 								<p>Overrides EventEmitter.emit</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1093">node/index.d.ts:1093</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1094">node/index.d.ts:1094</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -364,7 +364,7 @@
 								<p>Inherited from EventEmitter.eventNames</p>
 								<p>Overrides EventEmitter.eventNames</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1094">node/index.d.ts:1094</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1095">node/index.d.ts:1095</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -383,7 +383,7 @@
 								<p>Inherited from EventEmitter.getMaxListeners</p>
 								<p>Overrides EventEmitter.getMaxListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1090">node/index.d.ts:1090</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1091">node/index.d.ts:1091</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -501,7 +501,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.listenerCount</p>
 								<p>Overrides EventEmitter.listenerCount</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1095">node/index.d.ts:1095</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1096">node/index.d.ts:1096</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -526,7 +526,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.listeners</p>
 								<p>Overrides EventEmitter.listeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1091">node/index.d.ts:1091</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1092">node/index.d.ts:1092</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -551,7 +551,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.off</p>
 								<p>Overrides EventEmitter.off</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1087">node/index.d.ts:1087</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1088">node/index.d.ts:1088</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -597,7 +597,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.on</p>
 								<p>Overrides EventEmitter.on</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1082">node/index.d.ts:1082</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1083">node/index.d.ts:1083</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -643,7 +643,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.once</p>
 								<p>Overrides EventEmitter.once</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1083">node/index.d.ts:1083</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1084">node/index.d.ts:1084</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -689,7 +689,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.prependListener</p>
 								<p>Overrides EventEmitter.prependListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1084">node/index.d.ts:1084</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1085">node/index.d.ts:1085</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -735,7 +735,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.prependOnceListener</p>
 								<p>Overrides EventEmitter.prependOnceListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1085">node/index.d.ts:1085</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1086">node/index.d.ts:1086</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -781,7 +781,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.rawListeners</p>
 								<p>Overrides EventEmitter.rawListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1092">node/index.d.ts:1092</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1093">node/index.d.ts:1093</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -806,7 +806,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.removeAllListeners</p>
 								<p>Overrides EventEmitter.removeAllListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1088">node/index.d.ts:1088</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1089">node/index.d.ts:1089</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -831,7 +831,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.removeListener</p>
 								<p>Overrides EventEmitter.removeListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1086">node/index.d.ts:1086</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1087">node/index.d.ts:1087</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -877,7 +877,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 								<p>Inherited from EventEmitter.setMaxListeners</p>
 								<p>Overrides EventEmitter.setMaxListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1089">node/index.d.ts:1089</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1090">node/index.d.ts:1090</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -901,7 +901,7 @@ handler.handle({ schema, handler: <span class="hljs-function">(<span class="hljs
 							<aside class="tsd-sources">
 								<p>Inherited from EventEmitter.listenerCount</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1078">node/index.d.ts:1078</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1079">node/index.d.ts:1079</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/doc/classes/publisher.html
+++ b/doc/classes/publisher.html
@@ -262,7 +262,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from EventEmitter.defaultMaxListeners</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1079">node/index.d.ts:1079</a></li>
+							<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1080">node/index.d.ts:1080</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -281,7 +281,7 @@
 								<p>Inherited from EventEmitter.addListener</p>
 								<p>Overrides EventEmitter.addListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1081">node/index.d.ts:1081</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1082">node/index.d.ts:1082</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -327,7 +327,7 @@
 								<p>Inherited from EventEmitter.emit</p>
 								<p>Overrides EventEmitter.emit</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1093">node/index.d.ts:1093</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1094">node/index.d.ts:1094</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -386,7 +386,7 @@
 								<p>Inherited from EventEmitter.eventNames</p>
 								<p>Overrides EventEmitter.eventNames</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1094">node/index.d.ts:1094</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1095">node/index.d.ts:1095</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -405,7 +405,7 @@
 								<p>Inherited from EventEmitter.getMaxListeners</p>
 								<p>Overrides EventEmitter.getMaxListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1090">node/index.d.ts:1090</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1091">node/index.d.ts:1091</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -477,7 +477,7 @@
 								<p>Inherited from EventEmitter.listenerCount</p>
 								<p>Overrides EventEmitter.listenerCount</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1095">node/index.d.ts:1095</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1096">node/index.d.ts:1096</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -502,7 +502,7 @@
 								<p>Inherited from EventEmitter.listeners</p>
 								<p>Overrides EventEmitter.listeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1091">node/index.d.ts:1091</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1092">node/index.d.ts:1092</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -527,7 +527,7 @@
 								<p>Inherited from EventEmitter.off</p>
 								<p>Overrides EventEmitter.off</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1087">node/index.d.ts:1087</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1088">node/index.d.ts:1088</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -573,7 +573,7 @@
 								<p>Inherited from EventEmitter.on</p>
 								<p>Overrides EventEmitter.on</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1082">node/index.d.ts:1082</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1083">node/index.d.ts:1083</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -619,7 +619,7 @@
 								<p>Inherited from EventEmitter.once</p>
 								<p>Overrides EventEmitter.once</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1083">node/index.d.ts:1083</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1084">node/index.d.ts:1084</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -665,7 +665,7 @@
 								<p>Inherited from EventEmitter.prependListener</p>
 								<p>Overrides EventEmitter.prependListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1084">node/index.d.ts:1084</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1085">node/index.d.ts:1085</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -711,7 +711,7 @@
 								<p>Inherited from EventEmitter.prependOnceListener</p>
 								<p>Overrides EventEmitter.prependOnceListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1085">node/index.d.ts:1085</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1086">node/index.d.ts:1086</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -800,7 +800,7 @@
 								<p>Inherited from EventEmitter.rawListeners</p>
 								<p>Overrides EventEmitter.rawListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1092">node/index.d.ts:1092</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1093">node/index.d.ts:1093</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -825,7 +825,7 @@
 								<p>Inherited from EventEmitter.removeAllListeners</p>
 								<p>Overrides EventEmitter.removeAllListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1088">node/index.d.ts:1088</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1089">node/index.d.ts:1089</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -850,7 +850,7 @@
 								<p>Inherited from EventEmitter.removeListener</p>
 								<p>Overrides EventEmitter.removeListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1086">node/index.d.ts:1086</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1087">node/index.d.ts:1087</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -896,7 +896,7 @@
 								<p>Inherited from EventEmitter.setMaxListeners</p>
 								<p>Overrides EventEmitter.setMaxListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1089">node/index.d.ts:1089</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1090">node/index.d.ts:1090</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -920,7 +920,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from EventEmitter.listenerCount</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1078">node/index.d.ts:1078</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1079">node/index.d.ts:1079</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/doc/classes/server.html
+++ b/doc/classes/server.html
@@ -308,7 +308,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from EventEmitter.defaultMaxListeners</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1079">node/index.d.ts:1079</a></li>
+							<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1080">node/index.d.ts:1080</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -383,7 +383,7 @@
 								<p>Inherited from EventEmitter.addListener</p>
 								<p>Overrides EventEmitter.addListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1081">node/index.d.ts:1081</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1082">node/index.d.ts:1082</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -485,7 +485,7 @@
 								<p>Inherited from EventEmitter.emit</p>
 								<p>Overrides EventEmitter.emit</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1093">node/index.d.ts:1093</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1094">node/index.d.ts:1094</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -544,7 +544,7 @@
 								<p>Inherited from EventEmitter.eventNames</p>
 								<p>Overrides EventEmitter.eventNames</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1094">node/index.d.ts:1094</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1095">node/index.d.ts:1095</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">symbol</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -563,7 +563,7 @@
 								<p>Inherited from EventEmitter.getMaxListeners</p>
 								<p>Overrides EventEmitter.getMaxListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1090">node/index.d.ts:1090</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1091">node/index.d.ts:1091</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -642,7 +642,7 @@
 								<p>Inherited from EventEmitter.listenerCount</p>
 								<p>Overrides EventEmitter.listenerCount</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1095">node/index.d.ts:1095</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1096">node/index.d.ts:1096</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -667,7 +667,7 @@
 								<p>Inherited from EventEmitter.listeners</p>
 								<p>Overrides EventEmitter.listeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1091">node/index.d.ts:1091</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1092">node/index.d.ts:1092</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -692,7 +692,7 @@
 								<p>Inherited from EventEmitter.off</p>
 								<p>Overrides EventEmitter.off</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1087">node/index.d.ts:1087</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1088">node/index.d.ts:1088</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -738,7 +738,7 @@
 								<p>Inherited from EventEmitter.on</p>
 								<p>Overrides EventEmitter.on</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1082">node/index.d.ts:1082</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1083">node/index.d.ts:1083</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -784,7 +784,7 @@
 								<p>Inherited from EventEmitter.once</p>
 								<p>Overrides EventEmitter.once</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1083">node/index.d.ts:1083</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1084">node/index.d.ts:1084</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -830,7 +830,7 @@
 								<p>Inherited from EventEmitter.prependListener</p>
 								<p>Overrides EventEmitter.prependListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1084">node/index.d.ts:1084</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1085">node/index.d.ts:1085</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -876,7 +876,7 @@
 								<p>Inherited from EventEmitter.prependOnceListener</p>
 								<p>Overrides EventEmitter.prependOnceListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1085">node/index.d.ts:1085</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1086">node/index.d.ts:1086</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -922,7 +922,7 @@
 								<p>Inherited from EventEmitter.rawListeners</p>
 								<p>Overrides EventEmitter.rawListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1092">node/index.d.ts:1092</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1093">node/index.d.ts:1093</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -947,7 +947,7 @@
 								<p>Inherited from EventEmitter.removeAllListeners</p>
 								<p>Overrides EventEmitter.removeAllListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1088">node/index.d.ts:1088</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1089">node/index.d.ts:1089</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -972,7 +972,7 @@
 								<p>Inherited from EventEmitter.removeListener</p>
 								<p>Overrides EventEmitter.removeListener</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1086">node/index.d.ts:1086</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1087">node/index.d.ts:1087</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1049,7 +1049,7 @@
 								<p>Inherited from EventEmitter.setMaxListeners</p>
 								<p>Overrides EventEmitter.setMaxListeners</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1089">node/index.d.ts:1089</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1090">node/index.d.ts:1090</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1104,7 +1104,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from EventEmitter.listenerCount</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1078">node/index.d.ts:1078</a></li>
+									<li>Defined in <a href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/index.d.ts#L1079">node/index.d.ts:1079</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,9 +150,9 @@
 			}
 		},
 		"@sinonjs/commons": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-			"integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+			"integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
@@ -211,9 +211,9 @@
 			}
 		},
 		"@types/chai": {
-			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.6.tgz",
-			"integrity": "sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==",
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+			"integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
 			"dev": true
 		},
 		"@types/chai-as-promised": {
@@ -296,9 +296,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.117",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.117.tgz",
-			"integrity": "sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw=="
+			"version": "4.14.118",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
+			"integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw=="
 		},
 		"@types/marked": {
 			"version": "0.4.2",
@@ -324,9 +324,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-			"integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
+			"version": "10.12.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+			"integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
 		},
 		"@types/range-parser": {
 			"version": "1.2.2",
@@ -489,9 +489,9 @@
 			"dev": true
 		},
 		"avsc": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/avsc/-/avsc-5.4.5.tgz",
-			"integrity": "sha512-TSmyWmUKup9zdYdA5sS0Xd8Q+Z+Bn2dVyJ0y7Poi/fFbDo+UKqemRybAg+deeJecDZPpp9pgOvIq6gTEeW33sA=="
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/avsc/-/avsc-5.4.6.tgz",
+			"integrity": "sha512-8bbABwEjGB2GoFI7INkMxPB9bro+Zh4O4NLtnOP+NIsElMY7ab91IrMIxlks3PUw0WfWWDknFXC/9GBlWLgD+A=="
 		},
 		"axios": {
 			"version": "0.18.0",
@@ -2713,18 +2713,18 @@
 			}
 		},
 		"sinon": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.0.0.tgz",
-			"integrity": "sha512-8OrSYFPZ9xaECfi1ayVMd0ihYCW2OZYgX3rBczrB990gHZMM+aftvhNTJazGz/luS0Us9NWgD5P3KGQ7kYZvGg==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+			"integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.0.2",
+				"@sinonjs/commons": "^1.2.0",
 				"@sinonjs/formatio": "^3.0.0",
 				"@sinonjs/samsam": "^2.1.2",
 				"diff": "^3.5.0",
 				"lodash.get": "^4.4.2",
 				"lolex": "^3.0.0",
-				"nise": "^1.4.5",
+				"nise": "^1.4.6",
 				"supports-color": "^5.5.0",
 				"type-detect": "^4.0.8"
 			},
@@ -2965,9 +2965,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
-			"integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,14 +137,14 @@
 			}
 		},
 		"@financialforcedev/orizuru-transport-rabbitmq": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@financialforcedev/orizuru-transport-rabbitmq/-/orizuru-transport-rabbitmq-5.0.0.tgz",
-			"integrity": "sha512-FW18lKjh6AJB4XMEhjBMLAt5zSyvmO+MMXJSDs7PQ440TwhsnDZS0BSzryQUVMy6Tedb+DJKTdZyHkp/Inzxrw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@financialforcedev/orizuru-transport-rabbitmq/-/orizuru-transport-rabbitmq-5.0.1.tgz",
+			"integrity": "sha512-kvYFnbgidD550GNPPU4x1ol8KqF5MnBaneWgFi3x7rs4WW+Xfvtf3JBCFBc/cEuWvvsCWfESV0p+yncXEPcrNw==",
 			"dev": true,
 			"requires": {
 				"@types/amqplib": "0.5.8",
-				"@types/lodash": "^4.14.117",
-				"@types/node": "^10.12.0",
+				"@types/lodash": "^4.14.118",
+				"@types/node": "^10.12.2",
 				"amqplib": "^0.5.2",
 				"lodash": "^4.17.11"
 			}
@@ -554,9 +554,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-			"integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
 			"dev": true
 		},
 		"body-parser": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
 	"dependencies": {
 		"@types/express": "^4.16.0",
 		"@types/fs-extra": "^5.0.4",
-		"@types/lodash": "^4.14.117",
-		"@types/node": "^10.12.0",
-		"avsc": "^5.4.5",
+		"@types/lodash": "^4.14.118",
+		"@types/node": "^10.12.2",
+		"avsc": "^5.4.6",
 		"express": "^4.16.4",
 		"fs-extra": "^7.0.0",
 		"http-status-codes": "^1.3.0",
@@ -45,7 +45,7 @@
 	},
 	"devDependencies": {
 		"@financialforcedev/orizuru-transport-rabbitmq": "^5.0.0",
-		"@types/chai": "^4.1.6",
+		"@types/chai": "^4.1.7",
 		"@types/chai-as-promised": "^7.1.0",
 		"@types/mocha": "^5.2.5",
 		"@types/sinon": "^5.0.5",
@@ -57,12 +57,12 @@
 		"debug-plus": "^1.2.2",
 		"mocha": "^5.2.0",
 		"nyc": "^13.1.0",
-		"sinon": "^7.0.0",
+		"sinon": "^7.1.1",
 		"sinon-chai": "^3.2.0",
 		"supertest": "^3.3.0",
 		"ts-node": "^7.0.1",
 		"tslint": "^5.11.0",
 		"typedoc": "^0.13.0",
-		"typescript": "^3.1.3"
+		"typescript": "^3.1.6"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"lodash": "^4.17.11"
 	},
 	"devDependencies": {
-		"@financialforcedev/orizuru-transport-rabbitmq": "^5.0.0",
+		"@financialforcedev/orizuru-transport-rabbitmq": "^5.0.1",
 		"@types/chai": "^4.1.7",
 		"@types/chai-as-promised": "^7.1.0",
 		"@types/mocha": "^5.2.5",

--- a/test/index/handler/messageHandler.test.ts
+++ b/test/index/handler/messageHandler.test.ts
@@ -95,7 +95,7 @@ describe('index/handler/messageHandler', () => {
 		config.handler.returns(null);
 
 		// When
-		await messageHandler(server, config)(new Buffer('test'));
+		await messageHandler(server, config)(Buffer.from('test'));
 
 		// Then
 		expect(config.handler).to.have.been.calledOnce;
@@ -117,7 +117,7 @@ describe('index/handler/messageHandler', () => {
 
 		// When
 
-		await messageHandler(server, config)(new Buffer('test'));
+		await messageHandler(server, config)(Buffer.from('test'));
 
 		// Then
 		expect(config.handler).to.have.been.calledOnce;
@@ -138,7 +138,7 @@ describe('index/handler/messageHandler', () => {
 		config.handler.throws(expectedError);
 
 		// When
-		await messageHandler(server, config)(new Buffer('test'));
+		await messageHandler(server, config)(Buffer.from('test'));
 
 		// Then
 		expect(config.handler).to.have.been.calledOnce;
@@ -157,7 +157,7 @@ describe('index/handler/messageHandler', () => {
 		sinon.stub(Transport.prototype, 'decode').throws(expectedError);
 
 		// When
-		messageHandler(server, config)(new Buffer('test'));
+		messageHandler(server, config)(Buffer.from('test'));
 
 		// Then
 		expect(server.info).to.have.been.calledOnce;


### PR DESCRIPTION
- Update all dependencies to latest versions
- Remove all references to `new Buffer()`
	- Use `Buffer.from()` instead to remove deprecation warnings