### PR TITLE
Release/2018 10 07

### DIFF
--- a/CHANGELOG-9.md
+++ b/CHANGELOG-9.md
@@ -1,5 +1,11 @@
 # @financialforcedev/orizuru
 
+## 9.0.1
+
+- Update all dependencies to latest versions
+- Remove all references to `new Buffer()`
+	- Use `Buffer.from()` instead to remove deprecation warnings
+
 ## 9.0.0
 
 - The `addRoute` method can now add synchronous APIs.

--- a/doc/classes/server.html
+++ b/doc/classes/server.html
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L69">index/server.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L72">index/server.ts:72</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">http<wbr>Server<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">http.Server</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L69">index/server.ts:69</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L72">index/server.ts:72</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="../interfaces/options.iserver.html" class="tsd-signature-type">IServer</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L63">index/server.ts:63</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L66">index/server.ts:66</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">publisher<wbr>Impl<span class="tsd-signature-symbol">:</span> <a href="publisher.html" class="tsd-signature-type">Publisher</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L64">index/server.ts:64</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L67">index/server.ts:67</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">router<wbr>Configuration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L67">index/server.ts:67</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L70">index/server.ts:70</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -247,7 +247,7 @@
 					<div class="tsd-signature tsd-kind-icon">server<span class="tsd-signature-symbol">:</span> <a href="../interfaces/iserverimpl.html" class="tsd-signature-type">IServerImpl</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L65">index/server.ts:65</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L68">index/server.ts:68</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -257,7 +257,7 @@
 					<div class="tsd-signature tsd-kind-icon">validator<span class="tsd-signature-symbol">:</span> <a href="routevalidator.html" class="tsd-signature-type">RouteValidator</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L66">index/server.ts:66</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L69">index/server.ts:69</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -267,7 +267,7 @@
 					<div class="tsd-signature tsd-kind-icon">ERROR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">unique symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L56">index/server.ts:56</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L59">index/server.ts:59</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 					<div class="tsd-signature tsd-kind-icon">INFO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">unique symbol</span><span class="tsd-signature-symbol"> =&nbsp;Symbol()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L61">index/server.ts:61</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L64">index/server.ts:64</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -294,12 +294,17 @@
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-static">
 					<a name="route_method" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagStatic">Static</span> ROUTE_<wbr>METHOD</h3>
-					<div class="tsd-signature tsd-kind-icon">ROUTE_<wbr>METHOD<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;/Users/Matthew/GIT/financialforcedev/orizuru/src/index/server/routeMethod&quot;</span><span class="tsd-signature-symbol"> =&nbsp;ROUTE_METHOD</span></div>
+					<div class="tsd-signature tsd-kind-icon">ROUTE_<wbr>METHOD<span class="tsd-signature-symbol"></span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L51">index/server.ts:51</a></li>
+							<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L54">index/server.ts:54</a></li>
 						</ul>
 					</aside>
+					<div class="tsd-comment tsd-typography">
+						<div class="lead">
+							<p>The HTTP methods (DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE)</p>
+						</div>
+					</div>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-inherited tsd-is-static">
 					<a name="defaultmaxlisteners" class="tsd-anchor"></a>
@@ -325,7 +330,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L224">index/server.ts:224</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L227">index/server.ts:227</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -348,7 +353,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L215">index/server.ts:215</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L218">index/server.ts:218</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -427,7 +432,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L120">index/server.ts:120</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L123">index/server.ts:123</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -455,7 +460,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L175">index/server.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L178">index/server.ts:178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -511,7 +516,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L232">index/server.ts:232</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L235">index/server.ts:235</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -580,7 +585,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L240">index/server.ts:240</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L243">index/server.ts:243</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -611,7 +616,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L158">index/server.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L161">index/server.ts:161</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1016,7 +1021,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L192">index/server.ts:192</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L195">index/server.ts:195</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1072,7 +1077,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L200">index/server.ts:200</a></li>
+									<li>Defined in <a href="https://github.com/financialforcedev/orizuru/blob/master/src/index/server.ts#L203">index/server.ts:203</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru",
-	"version": "9.0.0",
+	"version": "9.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@financialforcedev/orizuru",
-	"version": "9.0.0",
+	"version": "9.0.1",
 	"description": "Streamlined communication between Heroku dynos / other worker processes",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/index/server.ts
+++ b/src/index/server.ts
@@ -48,6 +48,9 @@ const Router = express.Router;
  */
 export class Server extends EventEmitter {
 
+	/**
+	 * The HTTP methods (DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE)
+	 */
 	public static readonly ROUTE_METHOD = ROUTE_METHOD;
 
 	/**


### PR DESCRIPTION
## 9.0.1

- Update all dependencies to latest versions
- Remove all references to `new Buffer()`
	- Use `Buffer.from()` instead to remove deprecation warnings